### PR TITLE
Ads changes to consume from Ads DTS Export instead of AdWords DTS Export

### DIFF
--- a/dataform.json
+++ b/dataform.json
@@ -10,7 +10,8 @@
     "ga4_export_dataset": "DATASET_NAME",
     "ga4_export_table_suffix": "_*",
     "ga4_incremental_processing_days_back": "3",
-    "ads_export_data": "[{\"project\": \"PROJECT_ID\",\"dataset\": \"DATASET_NAME\", \"table_suffix\": \"_123456\"},{\"project\": \"PROJECT_ID\",\"dataset\": \"DATASET_NAME\",\"table_suffix\": \"_34567890\"}]"
+    "ads_export_data": "[{\"project\": \"PROJECT_ID\",\"dataset\": \"DATASET_NAME\", \"table_suffix\": \"_123456\"},{\"project\": \"PROJECT_ID\",\"dataset\": \"DATASET_NAME\",\"table_suffix\": \"_34567890\"}]",
+  "ads_metrics_lookback_days": "365"
   }
 } 
     

--- a/definitions/ads_domain/def/fact_ad_conversion_daily.sqlx
+++ b/definitions/ads_domain/def/fact_ad_conversion_daily.sqlx
@@ -26,10 +26,10 @@ CREATE TABLE IF NOT EXISTS ${self()}
   date_id INT64,
   ad_id STRING,
   device STRING,
-  conversion_tracker_id STRING,
+  --conversion_tracker_id STRING,
   ad_conversion_type STRING,
   ad_conversion_name STRING,
-  value FLOAT64,
+  value NUMERIC,
   quantity FLOAT64
 );
  

--- a/definitions/ads_domain/google_ads/product_v1/ad_conversions.sqlx
+++ b/definitions/ads_domain/google_ads/product_v1/ad_conversions.sqlx
@@ -27,7 +27,7 @@ SELECT
   dim.campaign_id,
   dim.campaign_name,
   fact.device,
-  fact.conversion_tracker_id,
+  --fact.conversion_tracker_id,
   fact.ad_conversion_type,
   fact.ad_conversion_name,
   fact.quantity,

--- a/definitions/ads_domain/google_ads/update/update_fact_ad_conversion_daily.sqlx
+++ b/definitions/ads_domain/google_ads/update/update_fact_ad_conversion_daily.sqlx
@@ -25,7 +25,7 @@ WITH landing AS (
     dim_ads.ad_id as ad_id,
     l.date_id as date_id,
     l.device as device,
-    l.conversion_tracker_id as conversion_tracker_id,
+    --l.conversion_tracker_id as conversion_tracker_id,
     l.ad_conversion_type as ad_conversion_type,
     l.ad_conversion_name as ad_conversion_name,
     l.value as value,
@@ -50,7 +50,7 @@ warehouse AS (
     date_id,
     ad_id,
     device,
-    conversion_tracker_id,
+    --conversion_tracker_id,
     ad_conversion_type,
     ad_conversion_name,
     value,
@@ -75,8 +75,8 @@ FROM landing l
 LEFT JOIN warehouse w ON
   l.ad_id = w.ad_id AND
   l.date_id = w.date_id AND
-  l.device = w.device AND
-  l.conversion_tracker_id = w.conversion_tracker_id
+  l.device = w.device --AND
+  --l.conversion_tracker_id = w.conversion_tracker_id
 
 post_operations {
     # Update older versions of the fact
@@ -98,7 +98,7 @@ post_operations {
     l.date_id as date_id,
     l.ad_id as ad_id,
     l.device as device,
-    l.conversion_tracker_id as conversion_tracker_id,
+    --l.conversion_tracker_id as conversion_tracker_id,
     l.ad_conversion_type as ad_conversion_type,
     l.ad_conversion_name as ad_conversion_name,
     l.value as value,

--- a/definitions/ads_domain/google_ads/views/ad.sqlx
+++ b/definitions/ads_domain/google_ads/views/ad.sqlx
@@ -18,14 +18,25 @@ config {
   schema: functions.baseSchema("ads"),
   tags: ["ads"]
 }
+js {
+  const columns = 
+    `ad_group_ad_ad_id,
+    ad_group_ad_ad_group,
+    customer_id,
+    campaign_id,
+    ad_group_ad_ad_type,
+    ad_group_ad_status`;
+
+  const union = functions.buildViewUnion(columns, "ads", "p_ads_Ad");
+}
 SELECT DISTINCT
-  "GOOGLE_ADS" as ad_system,
-  CAST(ExternalCustomerId AS STRING) as account_id,
-  CAST(CampaignId AS STRING) as campaign_id,
-  CAST(AdGroupId AS STRING) as adgroup_id,
-  CAST(CreativeId AS STRING) as creative_id,
-  AdType as ad_type,
-  Status as ad_status
+  "GOOGLE_ADS" AS ad_system,
+  CAST(ad_group_ad_ad_id AS STRING) AS creative_id,
+  SPLIT(ad_group_ad_ad_group,'/')[ORDINAL(4)] AS adgroup_id, --extract ad_group_id from ad_group string
+  CAST(customer_id AS STRING) AS account_id,
+  CAST(campaign_id AS STRING) AS campaign_id,
+  ad_group_ad_ad_type AS ad_type,
+  ad_group_ad_status AS ad_status
 FROM (
-${functions.buildViewUnion("ExternalCustomerId, CampaignId, AdGroupId, CreativeId, AdType, Status", "adwords", "Ad")}
+${union}
 )

--- a/definitions/ads_domain/google_ads/views/ad_conversion_stats.sqlx
+++ b/definitions/ads_domain/google_ads/views/ad_conversion_stats.sqlx
@@ -18,22 +18,46 @@ config {
   schema: functions.baseSchema("ads"),
   tags: ["ads"]
 }
+js {
+  const lookbackDays = dataform.projectConfig.vars.ads_metrics_lookback_days;
+  
+  const columns = 
+    `ad_group_ad_ad_id,
+    customer_id,
+    campaign_id,
+    ad_group_ad_ad_group,
+    segments_date,
+    segments_device,
+    segments_conversion_action_category,
+    segments_conversion_action_name,
+    metrics_conversions_value,
+    metrics_conversions`;
+    
+  const union = functions.buildViewUnion(columns, "ads", "p_ads_AdConversionStats", lookbackDays);
+}
 SELECT
-  "GOOGLE_ADS" as ad_system,
-  CAST(ExternalCustomerId AS STRING) as account_id,
-  CAST(CampaignId AS STRING) as campaign_id,
-  CAST(AdGroupId AS STRING) as adgroup_id,
-  CAST(CreativeId AS STRING) as creative_id,
-  CAST(CAST(Date AS STRING FORMAT 'YYYYMMDD') AS INT64) as date_id,
-  CAST(ConversionTrackerId AS STRING) as conversion_tracker_id,
-  Device as device,
-  ConversionCategoryName as ad_conversion_type,
-  ConversionTypeName as ad_conversion_name,
-  SUM(ConversionValue) as value,
-  SUM(Conversions) as quantity
+  "GOOGLE_ADS" AS ad_system,
+  CAST(ad_group_ad_ad_id AS STRING) AS creative_id,
+  CAST(customer_id AS STRING) AS account_id,
+  CAST(campaign_id AS STRING) AS campaign_id,
+  SPLIT(ad_group_ad_ad_group,'/')[ORDINAL(4)] AS adgroup_id, --extract ad_group_id from ad_group string
+  CAST(CAST(segments_date AS STRING FORMAT 'YYYYMMDD') AS INT64) AS date_id,
+  segments_device AS device,
+  segments_conversion_action_category AS ad_conversion_type,
+  segments_conversion_action_name AS ad_conversion_name,
+  SUM(CAST(metrics_conversions_value AS NUMERIC)) AS value, --cast to numeric for currency
+  SUM(metrics_conversions) AS quantity
 FROM (
 SELECT DISTINCT * FROM (
-${functions.buildViewUnion("ExternalCustomerId,CampaignId,AdGroupId,CreativeId,Date,ConversionTrackerId,Device,ConversionCategoryName,ConversionTypeName,ConversionValue,Conversions", "adwords", "p_AdConversionStats", 365)}
+  ${union}
 )
 )
-GROUP BY 1,2,3,4,5,6,7,8,9,10
+GROUP BY
+  creative_id,
+  account_id,
+  campaign_id,
+  adgroup_id,
+  date_id,
+  device,
+  ad_conversion_type,
+  ad_conversion_name

--- a/definitions/ads_domain/google_ads/views/ad_stats.sqlx
+++ b/definitions/ads_domain/google_ads/views/ad_stats.sqlx
@@ -18,20 +18,42 @@ config {
   schema: functions.baseSchema("ads"),
   tags: ["ads"]
 }
+js {
+  const lookbackDays = dataform.projectConfig.vars.ads_metrics_lookback_days;
+
+  const columns = 
+    `ad_group_ad_ad_id,
+    customer_id,
+    campaign_id,
+    ad_group_ad_ad_group,
+    segments_date,
+    segments_device,
+    metrics_impressions,
+    metrics_clicks,
+    metrics_cost_micros`;
+
+  const union = functions.buildViewUnion(columns, "ads", "p_ads_AdBasicStats", lookbackDays)
+}
 SELECT
-  "GOOGLE_ADS" as ad_system,
-  CAST(ExternalCustomerId AS STRING) as account_id,
-  CAST(CampaignId AS STRING) as campaign_id,
-  CAST(AdGroupId AS STRING) as adgroup_id,
-  CAST(CreativeId AS STRING) as creative_id,
-  CAST(CAST(Date AS STRING FORMAT 'YYYYMMDD') AS INT64) as date_id,
-  Device as device,
-  SUM(Impressions) as impressions,
-  SUM(Clicks) as clicks,
-  CAST(SUM(Cost) as NUMERIC) as cost  --cast to numeric for currency
+  "GOOGLE_ADS" AS ad_system,
+  CAST(ad_group_ad_ad_id AS STRING) AS creative_id,
+  CAST(customer_id AS STRING) as account_id,
+  CAST(campaign_id AS STRING) as campaign_id,
+  SPLIT(ad_group_ad_ad_group,'/')[ORDINAL(4)] AS adgroup_id, --extract ad_group_id from ad_group string
+  CAST(CAST(segments_date AS STRING FORMAT 'YYYYMMDD') AS INT64) as date_id,
+  segments_device AS device,
+  SUM(metrics_impressions) AS impressions,
+  SUM(metrics_clicks) AS clicks,
+  SUM(CAST (metrics_cost_micros AS NUMERIC)) AS cost  --cast to numeric for currency
 FROM (
   SELECT DISTINCT * FROM (
-${functions.buildViewUnion("ExternalCustomerId,CampaignId,AdGroupId,CreativeId,Date,Device,Impressions,Clicks,Cost,Ctr", "adwords", "p_AdStats", 365)}
+${union}
   )
 )
-GROUP BY 1,2,3,4,5,6,7
+GROUP BY 
+  creative_id,
+  account_id,
+  campaign_id,
+  adgroup_id,
+  date_id,
+  device

--- a/definitions/ads_domain/google_ads/views/adgroup.sqlx
+++ b/definitions/ads_domain/google_ads/views/adgroup.sqlx
@@ -18,14 +18,25 @@ config {
   schema: functions.baseSchema("ads"),
   tags: ["ads"]
 }
+js {
+  const columns =
+    `customer_id,
+    campaign_id,
+    ad_group_id,
+    ad_group_name,
+    ad_group_type,
+    ad_group_status`;
+
+  const union = functions.buildViewUnion(columns, "ads", "p_ads_AdGroup");
+}
 SELECT DISTINCT
-  "GOOGLE_ADS" as ad_system,
-  CAST(ExternalCustomerId AS STRING) as account_id,
-  CAST(CampaignId AS STRING) as campaign_id,
-  CAST(AdGroupId AS STRING) as adgroup_id,
-  AdGroupName as adgroup_name,
-  AdGroupType as adgroup_type,
-  AdGroupStatus as adgroup_status
+  "GOOGLE_ADS" AS ad_system,
+  CAST(customer_id AS STRING) AS account_id,
+  CAST(campaign_id AS STRING) AS campaign_id,
+  CAST(ad_group_id AS STRING) AS adgroup_id,
+  ad_group_name AS adgroup_name,
+  ad_group_type AS adgroup_type,
+  ad_group_status AS adgroup_status
 FROM (
-${functions.buildViewUnion("ExternalCustomerId,CampaignId,AdGroupId, AdGroupName, AdGroupType, AdGroupStatus", "adwords", "AdGroup")}
+${union}
 )

--- a/definitions/ads_domain/google_ads/views/campaign.sqlx
+++ b/definitions/ads_domain/google_ads/views/campaign.sqlx
@@ -18,12 +18,21 @@ config {
   schema: functions.baseSchema("ads"),
   tags: ["ads"]
 }
+js {
+  const columns =
+    `customer_id,
+    campaign_id,
+    campaign_name,
+    campaign_status`;
+
+  const union = functions.buildViewUnion(columns, "ads", "p_ads_Campaign");
+}
 SELECT DISTINCT
-  "GOOGLE_ADS" as ad_system,
-  CAST(ExternalCustomerId AS STRING) as account_id,
-  CAST(CampaignId AS STRING) as campaign_id,
-  CampaignName as campaign_name,
-  CampaignStatus as campaign_status
+  "GOOGLE_ADS" AS ad_system,
+  CAST(customer_id AS STRING) AS account_id,
+  CAST(campaign_id AS STRING) AS campaign_id,
+  campaign_name,
+  campaign_status
 FROM (
-${functions.buildViewUnion("ExternalCustomerId,CampaignId,CampaignName,CampaignStatus", "adwords", "Campaign")}
+${union}
 )

--- a/definitions/ads_domain/google_ads/views/customer.sqlx
+++ b/definitions/ads_domain/google_ads/views/customer.sqlx
@@ -18,12 +18,21 @@ config {
   schema: functions.baseSchema("ads"),
   tags: ["ads"]
 }
+js {
+  const columns =
+    `customer_id,
+    customer_descriptive_name,
+    customer_currency_code,
+    customer_time_zone`;
+
+  const union = functions.buildViewUnion(columns, "ads", "p_ads_Customer");
+}
 SELECT DISTINCT
-  "GOOGLE_ADS" as ad_system,
-  CAST(ExternalCustomerId AS STRING) as account_id,
-  CustomerDescriptiveName as account_name,
-  AccountCurrencyCode as currency,
-  AccountTimeZone as timezone
+  "GOOGLE_ADS" AS ad_system,
+  CAST(customer_id AS STRING) AS account_id,
+  customer_descriptive_name AS account_name,
+  customer_currency_code AS currency,
+  customer_time_zone AS timezone
 FROM (
-${functions.buildViewUnion("ExternalCustomerId,CustomerDescriptiveName,AccountCurrencyCode,AccountTimeZone", "adwords", "Customer")}
+${union}
 )

--- a/includes/constants.js
+++ b/includes/constants.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-const adwords = JSON.parse(dataform.projectConfig.vars.ads_export_data);
+const ads = JSON.parse(dataform.projectConfig.vars.ads_export_data);
 
-const settings = { "adwords": adwords};
+const settings = { "ads": ads};
 
 module.exports = { settings };


### PR DESCRIPTION
Major changes:
    - Updated base ads views to source data from Ads Preview DTS instead of AdWords which is being deprecated soon
    - Revised base ads views code to make function call to build union more readable
    - Added Ads statistics lookback days configuration variable to dataform.json to allow end user configuration